### PR TITLE
fix(ci): correctly use PUBLIC_URL basename

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,8 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  dev:
-    name: Development
+  preview:
+    name: Preview
     runs-on: ubuntu-20.04
     env:
       PREVIEW_REPO: PoliNetworkOrg/preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,6 @@
 name: Preview
 on:
   push:
-    branches:
-      - 'main'
   pull_request_target:
     types:
       - opened

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ const routes = [
   }
 ]
 
-const router = createBrowserRouter(routes, { basename: "/RankingsBeta" })
+const router = createBrowserRouter(routes)
 
 function Layout() {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,9 @@ const routes = [
   }
 ]
 
-const router = createBrowserRouter(routes)
+const router = createBrowserRouter(routes, {
+  basename: import.meta.env.BASE_URL
+})
 
 function Layout() {
   return (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,6 @@ import react from "@vitejs/plugin-react-swc"
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: process.env.PUBLIC_URL || '/',
+  base: process.env.PUBLIC_URL || "/",
   build: { outDir: "./dist" }
 })


### PR DESCRIPTION
- add `env,PUBLIC_URL` to `react-router` basename (using Vite `import.meta.env.BASE_URL")
- use `preview` workflow on each branch