### PR TITLE
fix: Table no data message

### DIFF
--- a/src/routes/view/viewer/Table.tsx
+++ b/src/routes/view/viewer/Table.tsx
@@ -182,10 +182,12 @@ export default function Table({ rows }: TableProps) {
             ) : (
               <TableRow>
                 <TableCell
-                  colSpan={columns.length}
+                  colSpan={table.getHeaderGroups()[1].headers.length}
                   className="h-24 text-center"
                 >
-                  Nessun dato disponibile.
+                  {rows.length > 0
+                    ? "Nessuna riga trovata"
+                    : "Nessun dato disponibile"}
                 </TableCell>
               </TableRow>
             )}

--- a/src/routes/view/viewer/index.tsx
+++ b/src/routes/view/viewer/index.tsx
@@ -156,7 +156,7 @@ export const viewerRoute = new Route({
         <div className="flex w-full flex-col gap-4 overflow-x-auto">
           {selectedPhase?.name === ranking.phase ? (
             <div className="col-start-1 col-end-3 row-start-1 row-end-2 overflow-y-auto scrollbar-thin">
-              {table && table.rows.length > 0 ? (
+              {table ? (
                 <Table school={school as School} rows={table.rows} />
               ) : (
                 <p>Nessun dato disponibile</p>


### PR DESCRIPTION
### Fixes
- complete table no render caused by `rows.length === 0` 
  - fix: render the table and make it handle the problem
- table no data message didn't fill the row width
  - fix: use the second table header length as `colSpan` value
  
### Note
This correction was made with the perspective of implementing the filters in the table.