### PR TITLE
feat(DevSettings): add view to compare data between refs 

### DIFF
--- a/src/components/DevSettings.tsx
+++ b/src/components/DevSettings.tsx
@@ -1,10 +1,29 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "./ui/button";
 import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
-import { DATA_REF, LINKS } from "@/utils/constants";
+import { DATA_REF, LINKS, SCHOOLS } from "@/utils/constants";
 import Data from "@/utils/data/data";
 import { useRouterContext } from "@tanstack/router";
 import { LuSettings2, LuX } from "react-icons/lu";
+import CustomMap from "@/utils/CustomMap";
+import School from "@/utils/types/data/School";
+import Ranking from "@/utils/types/data/parsed/Ranking";
+import Spinner from "./custom-ui/Spinner";
+import Page from "./custom-ui/Page";
+import { Badge } from "./ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./ui/table";
+
+type LocalData = {
+  main?: Data;
+  stable?: Data;
+};
 
 export default function DevSettings({ data }: { data?: Data }) {
   const [open, setOpen] = useState(false);
@@ -15,57 +34,72 @@ export default function DevSettings({ data }: { data?: Data }) {
     context.load();
   }
 
+  const [{ stable, main }, setLocalData] = useState<LocalData>({});
+
+  useEffect(() => {
+    const mainData = Data.init(DATA_REF.MAIN);
+    const stableData = Data.init(DATA_REF.STABLE);
+
+    Promise.all([mainData, stableData]).then(([main, stable]) =>
+      setLocalData({ main, stable }),
+    );
+  }, []);
+
   return (
     data && (
       <>
         <div
-          className={`fixed left-0 top-0 flex h-screen w-full flex-col items-start justify-start gap-4 border-slate-600 bg-white/20 p-4 backdrop-blur dark:bg-black/60 ${
-            open ? "border-t " : "hidden"
+          className={`fixed left-0 top-0 flex h-screen w-full bg-white dark:bg-slate-950 ${
+            open ? "" : "hidden"
           }`}
         >
-          <div className="flex w-full items-center justify-between">
-            <h3 className="text-2xl font-bold">Dev Settings</h3>
-            <Button
-              size="icon"
-              variant="outline"
-              onClick={() => setOpen(false)}
-            >
-              <LuX />
-            </Button>
-          </div>
-
-          <hr className="w-full border-slate-600" />
-
-          <Section title="WebApp Info">
-            <p>Version: {APP_VERSION}</p>
-          </Section>
-
-          <hr className="w-full border-slate-600" />
-
-          <Section title="Settings">
-            <div className="flex items-center gap-4">
-              <p>
-                Sorgente data{" "}
-                <a
-                  href={LINKS.dataRepoUrl}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  (repo)
-                </a>
-              </p>
-              <Tabs value={data.ref} onValueChange={handleChangeRef}>
-                <TabsList>
-                  <TabsTrigger className="block" value={DATA_REF.MAIN}>
-                    Main
-                  </TabsTrigger>
-                  <TabsTrigger className="block" value={DATA_REF.STABLE}>
-                    Stable
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
+          <Page className="gap-4" paddingTop={false}>
+            <div className="flex w-full items-center justify-between border-b border-slate-600 py-4">
+              <h3 className="text-2xl font-bold">Dev Settings</h3>
+              <Button
+                size="icon"
+                variant="outline"
+                onClick={() => setOpen(false)}
+              >
+                <LuX />
+              </Button>
             </div>
-          </Section>
+
+            <div className="flex h-full max-h-full w-full flex-col gap-4 overflow-y-scroll pb-12 pr-2 scrollbar-thin">
+              <Section title="WebApp Info" showHr={false}>
+                <p>Version: {APP_VERSION}</p>
+              </Section>
+
+              <Section title="Data info">
+                {stable && main && <DataSummary stable={stable} main={main} />}
+              </Section>
+
+              <Section title="Settings">
+                <div className="flex items-center gap-4">
+                  <p>
+                    Sorgente data{" "}
+                    <a
+                      href={LINKS.dataRepoUrl}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      (repo)
+                    </a>
+                  </p>
+                  <Tabs value={data.ref} onValueChange={handleChangeRef}>
+                    <TabsList>
+                      <TabsTrigger className="block" value={DATA_REF.STABLE}>
+                        Stable
+                      </TabsTrigger>
+                      <TabsTrigger className="block" value={DATA_REF.MAIN}>
+                        Main
+                      </TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+                </div>
+              </Section>
+            </div>
+          </Page>
         </div>
 
         {!open && (
@@ -86,12 +120,225 @@ export default function DevSettings({ data }: { data?: Data }) {
 type SectionProps = {
   title: string;
   children: React.ReactNode;
+  showHr?: boolean;
 };
-function Section({ title, children }: SectionProps) {
+function Section({ title, children, showHr = true }: SectionProps) {
   return (
-    <div className="flex flex-col items-start gap-2">
-      <h4 className="text-lg font-bold">{title}</h4>
-      {children}
+    <>
+      {showHr && <hr className="w-full border-slate-600" />}
+      <div className="flex w-full flex-col items-start gap-2">
+        <h4 className="text-lg font-bold">{title}</h4>
+        {children}
+      </div>
+    </>
+  );
+}
+
+type DataSummaryProps = {
+  main: Data;
+  stable: Data;
+};
+
+type SchoolData = {
+  main: Ranking[];
+  stable: Ranking[];
+  comparison: RefComparison;
+};
+
+type SchoolRankingsMap = CustomMap<School, SchoolData>;
+type YearData = {
+  comparison: RefComparison;
+  schools: SchoolRankingsMap;
+};
+type YearSchoolsRankingsMap = CustomMap<number, YearData>;
+
+type RefComparison = {
+  diffStableMain: number;
+  diffStableMainPercentage: number;
+};
+
+function DataSummary({ main, stable }: DataSummaryProps) {
+  const [currYear, setCurrYear] = useState<number>(new Date().getFullYear());
+  const MAX_YEARS = 2;
+  const [yearsRankings, setYearsRankings] = useState<
+    YearSchoolsRankingsMap | undefined
+  >();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isClicked, setIsClicked] = useState<boolean>(false);
+  const [canLoadMore, setCanLoadMore] = useState<boolean>(true);
+  const [yearsMaxRows, setYearsMaxRows] = useState<CustomMap<number, number>>(
+    new CustomMap(),
+  );
+
+  async function getYearData(year: number): Promise<YearData> {
+    const schoolMap: SchoolRankingsMap = new CustomMap();
+    let maxRows = 0;
+    let totalStableStudents = 0;
+    const mainComparison: RefComparison = {
+      diffStableMain: 0,
+      diffStableMainPercentage: 0,
+    };
+    for (const school of SCHOOLS) {
+      const mainData = await main.getAllYearRankings(school, year);
+      const stableData = await stable.getAllYearRankings(school, year);
+
+      totalStableStudents += stableData
+        .map((r) => r.rankingSummary.howManyStudents)
+        .reduce((a, b) => a + b);
+
+      const comparison = getComparison(stableData, mainData);
+      const schoolData: SchoolData = {
+        main: mainData,
+        stable: stableData,
+        comparison,
+      };
+
+      mainComparison.diffStableMain += comparison.diffStableMain;
+
+      const innerMax = Math.max(mainData.length, stableData.length);
+      maxRows = Math.max(maxRows, innerMax);
+      schoolMap.set(school, schoolData);
+    }
+
+    yearsMaxRows.set(year, maxRows);
+    setYearsMaxRows(yearsMaxRows);
+    mainComparison.diffStableMainPercentage =
+      (mainComparison.diffStableMain * 100) / totalStableStudents;
+
+    return {
+      schools: schoolMap,
+      comparison: mainComparison,
+    };
+  }
+
+  async function load(): Promise<void> {
+    setIsLoading(true);
+    const map: YearSchoolsRankingsMap = yearsRankings ?? new CustomMap();
+    let y = currYear;
+    for (let i = MAX_YEARS; i > 0; i--) {
+      if (y <= 2021) setCanLoadMore(false);
+      const yearData = await getYearData(y);
+      map.set(y, yearData);
+      y--;
+    }
+    setCurrYear(y);
+    setYearsRankings(map);
+    setIsLoading(false);
+    setIsClicked(true);
+  }
+
+  function getComparison(stable: Ranking[], main: Ranking[]): RefComparison {
+    const mainStudents = main
+      .map((r) => r.rankingSummary.howManyStudents)
+      .reduce((a, b) => a + b);
+    const stableStudents = stable
+      .map((r) => r.rankingSummary.howManyStudents)
+      .reduce((a, b) => a + b);
+
+    const diffStableMain = stableStudents - mainStudents;
+    const diffStableMainPercentage = (diffStableMain * 100) / stableStudents;
+
+    return {
+      diffStableMain,
+      diffStableMainPercentage,
+    };
+  }
+
+  return (
+    <div className="flex w-full flex-col items-start gap-4">
+      {!isLoading && !isClicked && (
+        <Button variant="outline" onClick={load}>
+          Load (potrebbe richiedere un po' di tempo)
+        </Button>
+      )}
+      {yearsRankings && (
+        <>
+          {yearsRankings?.entriesArr().map(([year, yearData]) => (
+            <div className="w-full p-2 dark:border-slate-600">
+              <div className="flex items-center gap-4">
+                <Badge>{year}</Badge>
+                <p>Global Comparison (stable - main)</p>
+                <p>{yearData.comparison.diffStableMain}</p> -
+                <p>
+                  {yearData.comparison.diffStableMainPercentage.toFixed(2)}%
+                </p>
+              </div>
+              <div className="mt-2 grid w-full grid-cols-2 grid-rows-2 gap-4">
+                {yearData.schools.entriesArr().map(([school, schoolData]) => {
+                  const dataByPhase = schoolData.stable
+                    .map((sr) => {
+                      const mr = schoolData.main.find(
+                        (rr) => rr.phase === sr.phase,
+                      );
+                      if (!mr) return [];
+
+                      return [
+                        sr.phase,
+                        sr.rankingSummary.howManyStudents.toString(),
+                        mr.rankingSummary.howManyStudents.toString(),
+                      ];
+                    })
+                    .filter((arr) => arr.length === 3);
+
+                  console.log(yearsMaxRows.get(year));
+                  const voidRowsNum =
+                    (yearsMaxRows.get(year) ?? 0) - dataByPhase.length;
+                  const voidRows: number[] = new Array(
+                    Math.max(voidRowsNum, 0),
+                  ).fill(0);
+                  return (
+                    <div className="h-full basis-[calc(50%-1rem)] rounded-md border border-slate-300 dark:border-slate-700 [&_*]:border-slate-300 [&_*]:dark:border-slate-700">
+                      <Table className="h-full [&_tr:nth-child(odd):not(:hover)]:bg-inherit dark:[&_tr:nth-child(odd):not(:hover)]:bg-inherit">
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>{school}</TableHead>
+                            <TableHead>{stable.ref}</TableHead>
+                            <TableHead>{main.ref}</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {dataByPhase.map((d) => {
+                            return (
+                              <TableRow key={d[0]}>
+                                <TableCell className="w-3/5">{d[0]}</TableCell>
+                                <TableCell className="w-1/5">{d[1]}</TableCell>
+                                <TableCell className="w-1/5">{d[2]}</TableCell>
+                              </TableRow>
+                            );
+                          })}
+                          {voidRows.map((_, i) => (
+                            <TableRow key={`void-${year}-${school}-${i}`}>
+                              <TableCell colSpan={3}>&nbsp;</TableCell>
+                            </TableRow>
+                          ))}
+                          <TableRow className="[&_*]:bg-slate-800">
+                            <TableCell>Comparison (stable - main)</TableCell>
+                            <TableCell>
+                              {schoolData.comparison.diffStableMain}
+                            </TableCell>
+                            <TableCell>
+                              {schoolData.comparison.diffStableMainPercentage.toFixed(
+                                2,
+                              )}
+                              %
+                            </TableCell>
+                          </TableRow>
+                        </TableBody>
+                      </Table>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+          {canLoadMore && (
+            <Button variant="outline" onClick={load}>
+              Load more
+            </Button>
+          )}
+        </>
+      )}
+      {isLoading && <Spinner className="flex-grow-0" />}
     </div>
   );
 }

--- a/src/components/DevSettings/DataSummary.tsx
+++ b/src/components/DevSettings/DataSummary.tsx
@@ -1,0 +1,225 @@
+import CustomMap from "@/utils/CustomMap";
+import School from "@/utils/types/data/School";
+import Ranking from "@/utils/types/data/parsed/Ranking";
+import { SCHOOLS } from "@/utils/constants";
+import Spinner from "../custom-ui/Spinner";
+import { Badge } from "../ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import Data from "@/utils/data/data";
+import { useState } from "react";
+import { Button } from "../ui/button";
+
+type DataSummaryProps = {
+  main: Data;
+  stable: Data;
+};
+
+type SchoolData = {
+  main: Ranking[];
+  stable: Ranking[];
+  comparison: RefComparison;
+};
+
+type SchoolRankingsMap = CustomMap<School, SchoolData>;
+type YearData = {
+  comparison: RefComparison;
+  schools: SchoolRankingsMap;
+};
+type YearSchoolsRankingsMap = CustomMap<number, YearData>;
+
+type RefComparison = {
+  diffStableMain: number;
+  diffStableMainPercentage: number;
+};
+
+export default function DataSummary({ main, stable }: DataSummaryProps) {
+  const [currYear, setCurrYear] = useState<number>(new Date().getFullYear());
+  const MAX_YEARS = 2;
+  const [yearsRankings, setYearsRankings] = useState<
+    YearSchoolsRankingsMap | undefined
+  >();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isClicked, setIsClicked] = useState<boolean>(false);
+  const [canLoadMore, setCanLoadMore] = useState<boolean>(true);
+  const [yearsMaxRows, setYearsMaxRows] = useState<CustomMap<number, number>>(
+    new CustomMap(),
+  );
+
+  async function getYearData(year: number): Promise<YearData> {
+    const schoolMap: SchoolRankingsMap = new CustomMap();
+    let maxRows = 0;
+    let totalStableStudents = 0;
+    const mainComparison: RefComparison = {
+      diffStableMain: 0,
+      diffStableMainPercentage: 0,
+    };
+    for (const school of SCHOOLS) {
+      const mainData = await main.getAllYearRankings(school, year);
+      const stableData = await stable.getAllYearRankings(school, year);
+
+      totalStableStudents += stableData
+        .map((r) => r.rankingSummary.howManyStudents)
+        .reduce((a, b) => a + b);
+
+      const comparison = getComparison(stableData, mainData);
+      const schoolData: SchoolData = {
+        main: mainData,
+        stable: stableData,
+        comparison,
+      };
+
+      mainComparison.diffStableMain += comparison.diffStableMain;
+
+      const innerMax = Math.max(mainData.length, stableData.length);
+      maxRows = Math.max(maxRows, innerMax);
+      schoolMap.set(school, schoolData);
+    }
+
+    yearsMaxRows.set(year, maxRows);
+    setYearsMaxRows(yearsMaxRows);
+    mainComparison.diffStableMainPercentage =
+      (mainComparison.diffStableMain * 100) / totalStableStudents;
+
+    return {
+      schools: schoolMap,
+      comparison: mainComparison,
+    };
+  }
+
+  async function load(): Promise<void> {
+    setIsLoading(true);
+    const map: YearSchoolsRankingsMap = yearsRankings ?? new CustomMap();
+    let y = currYear;
+    for (let i = MAX_YEARS; i > 0; i--) {
+      if (y <= 2021) setCanLoadMore(false);
+      const yearData = await getYearData(y);
+      map.set(y, yearData);
+      y--;
+    }
+    setCurrYear(y);
+    setYearsRankings(map);
+    setIsLoading(false);
+    setIsClicked(true);
+  }
+
+  function getComparison(stable: Ranking[], main: Ranking[]): RefComparison {
+    const mainStudents = main
+      .map((r) => r.rankingSummary.howManyStudents)
+      .reduce((a, b) => a + b);
+    const stableStudents = stable
+      .map((r) => r.rankingSummary.howManyStudents)
+      .reduce((a, b) => a + b);
+
+    const diffStableMain = stableStudents - mainStudents;
+    const diffStableMainPercentage = (diffStableMain * 100) / stableStudents;
+
+    return {
+      diffStableMain,
+      diffStableMainPercentage,
+    };
+  }
+
+  return (
+    <div className="flex w-full flex-col items-start gap-8">
+      {!isLoading && !isClicked && (
+        <Button variant="outline" onClick={load}>
+          Load (potrebbe richiedere un po' di tempo)
+        </Button>
+      )}
+      {yearsRankings && (
+        <>
+          {yearsRankings?.entriesArr().map(([year, yearData]) => (
+            <div className="w-full dark:border-slate-600">
+              <div className="flex items-center gap-4">
+                <Badge>{year}</Badge>
+                <p>Global Comparison (stable - main)</p>
+                <p>{yearData.comparison.diffStableMain}</p> -
+                <p>
+                  {yearData.comparison.diffStableMainPercentage.toFixed(2)}%
+                </p>
+              </div>
+              <div className="mt-2 grid w-full grid-cols-2 grid-rows-2 gap-4">
+                {yearData.schools.entriesArr().map(([school, schoolData]) => {
+                  const dataByPhase = schoolData.stable
+                    .map((sr) => {
+                      const mr = schoolData.main.find(
+                        (rr) => rr.phase === sr.phase,
+                      );
+                      if (!mr) return [];
+
+                      return [
+                        sr.phase,
+                        sr.rankingSummary.howManyStudents.toString(),
+                        mr.rankingSummary.howManyStudents.toString(),
+                      ];
+                    })
+                    .filter((arr) => arr.length === 3);
+
+                  const voidRowsNum =
+                    (yearsMaxRows.get(year) ?? 0) - dataByPhase.length;
+                  const voidRows: number[] = new Array(
+                    Math.max(voidRowsNum, 0),
+                  ).fill(0);
+                  return (
+                    <div className="h-full basis-[calc(50%-1rem)] rounded-md border border-slate-300 dark:border-slate-700 [&_*]:border-slate-300 [&_*]:dark:border-slate-700">
+                      <Table className="h-full [&_tr:nth-child(odd):not(:hover)]:bg-inherit dark:[&_tr:nth-child(odd):not(:hover)]:bg-inherit">
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>{school}</TableHead>
+                            <TableHead>{stable.ref}</TableHead>
+                            <TableHead>{main.ref}</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {dataByPhase.map((d) => {
+                            return (
+                              <TableRow key={d[0]}>
+                                <TableCell className="w-3/5">{d[0]}</TableCell>
+                                <TableCell className="w-1/5">{d[1]}</TableCell>
+                                <TableCell className="w-1/5">{d[2]}</TableCell>
+                              </TableRow>
+                            );
+                          })}
+                          {voidRows.map((_, i) => (
+                            <TableRow key={`void-${year}-${school}-${i}`}>
+                              <TableCell colSpan={3}>&nbsp;</TableCell>
+                            </TableRow>
+                          ))}
+                          <TableRow className="[&_*]:bg-slate-300 [&_*]:dark:bg-slate-800">
+                            <TableCell>Comparison (stable - main)</TableCell>
+                            <TableCell>
+                              {schoolData.comparison.diffStableMain}
+                            </TableCell>
+                            <TableCell>
+                              {schoolData.comparison.diffStableMainPercentage.toFixed(
+                                2,
+                              )}
+                              %
+                            </TableCell>
+                          </TableRow>
+                        </TableBody>
+                      </Table>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+          {canLoadMore && (
+            <Button variant="outline" onClick={load}>
+              Load more
+            </Button>
+          )}
+        </>
+      )}
+      {isLoading && <Spinner className="flex-grow-0" />}
+    </div>
+  );
+}

--- a/src/components/DevSettings/Section.tsx
+++ b/src/components/DevSettings/Section.tsx
@@ -1,0 +1,23 @@
+import Separator from "./Separator";
+
+type SectionProps = {
+  title: string;
+  children: React.ReactNode;
+  showHr?: boolean;
+};
+
+export default function Section({
+  title,
+  children,
+  showHr = true,
+}: SectionProps) {
+  return (
+    <>
+      {showHr && <Separator />}
+      <div className="flex w-full flex-col items-start gap-2">
+        <h4 className="text-lg font-bold">{title}</h4>
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/components/DevSettings/Separator.tsx
+++ b/src/components/DevSettings/Separator.tsx
@@ -1,0 +1,3 @@
+export default function Separator() {
+  return <hr className="w-full border-slate-800 dark:border-slate-600" />;
+}

--- a/src/components/DevSettings/Settings/SetDataRef.tsx
+++ b/src/components/DevSettings/Settings/SetDataRef.tsx
@@ -1,0 +1,36 @@
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useRouterContext } from "@tanstack/router";
+import { DATA_REF, LINKS } from "@/utils/constants";
+import Data from "@/utils/data/data";
+
+type Props = {
+  currentRef: DATA_REF;
+};
+export default function SetDataRef({ currentRef }: Props) {
+  const context = useRouterContext();
+
+  function handleChangeRef(refStr: string): void {
+    context.context.data = Data.init(refStr as DATA_REF);
+    context.load();
+  }
+  return (
+    <div className="flex items-center gap-4">
+      <p>
+        Sorgente data{" "}
+        <a href={LINKS.dataRepoUrl} target="_blank" rel="noreferrer noopener">
+          (repo)
+        </a>
+      </p>
+      <Tabs value={currentRef} onValueChange={handleChangeRef}>
+        <TabsList>
+          <TabsTrigger className="block" value={DATA_REF.STABLE}>
+            Stable
+          </TabsTrigger>
+          <TabsTrigger className="block" value={DATA_REF.MAIN}>
+            Main
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/components/DevSettings/Settings/index.tsx
+++ b/src/components/DevSettings/Settings/index.tsx
@@ -1,0 +1,15 @@
+import Data from "@/utils/data/data";
+import Section from "../Section";
+import SetDataRef from "./SetDataRef";
+
+type Props = {
+  data: Data;
+};
+
+export default function Settings({ data }: Props) {
+  return (
+    <Section title="Settings">
+      <SetDataRef currentRef={data.ref} />
+    </Section>
+  );
+}

--- a/src/components/DevSettings/index.tsx
+++ b/src/components/DevSettings/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { Button } from "./ui/button";
-import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
+import { Button } from "../ui/button";
+import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
 import { DATA_REF, LINKS, SCHOOLS } from "@/utils/constants";
 import Data from "@/utils/data/data";
 import { useRouterContext } from "@tanstack/router";
@@ -8,9 +8,9 @@ import { LuSettings2, LuX } from "react-icons/lu";
 import CustomMap from "@/utils/CustomMap";
 import School from "@/utils/types/data/School";
 import Ranking from "@/utils/types/data/parsed/Ranking";
-import Spinner from "./custom-ui/Spinner";
-import Page from "./custom-ui/Page";
-import { Badge } from "./ui/badge";
+import Spinner from "../custom-ui/Spinner";
+import Page from "../custom-ui/Page";
+import { Badge } from "../ui/badge";
 import {
   Table,
   TableBody,
@@ -18,7 +18,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "./ui/table";
+} from "../ui/table";
 
 type LocalData = {
   main?: Data;

--- a/src/components/DevSettings/index.tsx
+++ b/src/components/DevSettings/index.tsx
@@ -1,24 +1,12 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
-import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
-import { DATA_REF, LINKS, SCHOOLS } from "@/utils/constants";
 import Data from "@/utils/data/data";
-import { useRouterContext } from "@tanstack/router";
 import { LuSettings2, LuX } from "react-icons/lu";
-import CustomMap from "@/utils/CustomMap";
-import School from "@/utils/types/data/School";
-import Ranking from "@/utils/types/data/parsed/Ranking";
-import Spinner from "../custom-ui/Spinner";
 import Page from "../custom-ui/Page";
-import { Badge } from "../ui/badge";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "../ui/table";
+import { DATA_REF } from "@/utils/constants";
+import Section from "./Section";
+import DataSummary from "./DataSummary";
+import Settings from "./Settings";
 
 type LocalData = {
   main?: Data;
@@ -27,12 +15,6 @@ type LocalData = {
 
 export default function DevSettings({ data }: { data?: Data }) {
   const [open, setOpen] = useState(false);
-  const context = useRouterContext();
-
-  function handleChangeRef(refStr: string): void {
-    context.context.data = Data.init(refStr as DATA_REF);
-    context.load();
-  }
 
   const [{ stable, main }, setLocalData] = useState<LocalData>({});
 
@@ -74,30 +56,7 @@ export default function DevSettings({ data }: { data?: Data }) {
                 {stable && main && <DataSummary stable={stable} main={main} />}
               </Section>
 
-              <Section title="Settings">
-                <div className="flex items-center gap-4">
-                  <p>
-                    Sorgente data{" "}
-                    <a
-                      href={LINKS.dataRepoUrl}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                    >
-                      (repo)
-                    </a>
-                  </p>
-                  <Tabs value={data.ref} onValueChange={handleChangeRef}>
-                    <TabsList>
-                      <TabsTrigger className="block" value={DATA_REF.STABLE}>
-                        Stable
-                      </TabsTrigger>
-                      <TabsTrigger className="block" value={DATA_REF.MAIN}>
-                        Main
-                      </TabsTrigger>
-                    </TabsList>
-                  </Tabs>
-                </div>
-              </Section>
+              <Settings data={data} />
             </div>
           </Page>
         </div>
@@ -114,231 +73,5 @@ export default function DevSettings({ data }: { data?: Data }) {
         )}
       </>
     )
-  );
-}
-
-type SectionProps = {
-  title: string;
-  children: React.ReactNode;
-  showHr?: boolean;
-};
-function Section({ title, children, showHr = true }: SectionProps) {
-  return (
-    <>
-      {showHr && <hr className="w-full border-slate-600" />}
-      <div className="flex w-full flex-col items-start gap-2">
-        <h4 className="text-lg font-bold">{title}</h4>
-        {children}
-      </div>
-    </>
-  );
-}
-
-type DataSummaryProps = {
-  main: Data;
-  stable: Data;
-};
-
-type SchoolData = {
-  main: Ranking[];
-  stable: Ranking[];
-  comparison: RefComparison;
-};
-
-type SchoolRankingsMap = CustomMap<School, SchoolData>;
-type YearData = {
-  comparison: RefComparison;
-  schools: SchoolRankingsMap;
-};
-type YearSchoolsRankingsMap = CustomMap<number, YearData>;
-
-type RefComparison = {
-  diffStableMain: number;
-  diffStableMainPercentage: number;
-};
-
-function DataSummary({ main, stable }: DataSummaryProps) {
-  const [currYear, setCurrYear] = useState<number>(new Date().getFullYear());
-  const MAX_YEARS = 2;
-  const [yearsRankings, setYearsRankings] = useState<
-    YearSchoolsRankingsMap | undefined
-  >();
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [isClicked, setIsClicked] = useState<boolean>(false);
-  const [canLoadMore, setCanLoadMore] = useState<boolean>(true);
-  const [yearsMaxRows, setYearsMaxRows] = useState<CustomMap<number, number>>(
-    new CustomMap(),
-  );
-
-  async function getYearData(year: number): Promise<YearData> {
-    const schoolMap: SchoolRankingsMap = new CustomMap();
-    let maxRows = 0;
-    let totalStableStudents = 0;
-    const mainComparison: RefComparison = {
-      diffStableMain: 0,
-      diffStableMainPercentage: 0,
-    };
-    for (const school of SCHOOLS) {
-      const mainData = await main.getAllYearRankings(school, year);
-      const stableData = await stable.getAllYearRankings(school, year);
-
-      totalStableStudents += stableData
-        .map((r) => r.rankingSummary.howManyStudents)
-        .reduce((a, b) => a + b);
-
-      const comparison = getComparison(stableData, mainData);
-      const schoolData: SchoolData = {
-        main: mainData,
-        stable: stableData,
-        comparison,
-      };
-
-      mainComparison.diffStableMain += comparison.diffStableMain;
-
-      const innerMax = Math.max(mainData.length, stableData.length);
-      maxRows = Math.max(maxRows, innerMax);
-      schoolMap.set(school, schoolData);
-    }
-
-    yearsMaxRows.set(year, maxRows);
-    setYearsMaxRows(yearsMaxRows);
-    mainComparison.diffStableMainPercentage =
-      (mainComparison.diffStableMain * 100) / totalStableStudents;
-
-    return {
-      schools: schoolMap,
-      comparison: mainComparison,
-    };
-  }
-
-  async function load(): Promise<void> {
-    setIsLoading(true);
-    const map: YearSchoolsRankingsMap = yearsRankings ?? new CustomMap();
-    let y = currYear;
-    for (let i = MAX_YEARS; i > 0; i--) {
-      if (y <= 2021) setCanLoadMore(false);
-      const yearData = await getYearData(y);
-      map.set(y, yearData);
-      y--;
-    }
-    setCurrYear(y);
-    setYearsRankings(map);
-    setIsLoading(false);
-    setIsClicked(true);
-  }
-
-  function getComparison(stable: Ranking[], main: Ranking[]): RefComparison {
-    const mainStudents = main
-      .map((r) => r.rankingSummary.howManyStudents)
-      .reduce((a, b) => a + b);
-    const stableStudents = stable
-      .map((r) => r.rankingSummary.howManyStudents)
-      .reduce((a, b) => a + b);
-
-    const diffStableMain = stableStudents - mainStudents;
-    const diffStableMainPercentage = (diffStableMain * 100) / stableStudents;
-
-    return {
-      diffStableMain,
-      diffStableMainPercentage,
-    };
-  }
-
-  return (
-    <div className="flex w-full flex-col items-start gap-4">
-      {!isLoading && !isClicked && (
-        <Button variant="outline" onClick={load}>
-          Load (potrebbe richiedere un po' di tempo)
-        </Button>
-      )}
-      {yearsRankings && (
-        <>
-          {yearsRankings?.entriesArr().map(([year, yearData]) => (
-            <div className="w-full p-2 dark:border-slate-600">
-              <div className="flex items-center gap-4">
-                <Badge>{year}</Badge>
-                <p>Global Comparison (stable - main)</p>
-                <p>{yearData.comparison.diffStableMain}</p> -
-                <p>
-                  {yearData.comparison.diffStableMainPercentage.toFixed(2)}%
-                </p>
-              </div>
-              <div className="mt-2 grid w-full grid-cols-2 grid-rows-2 gap-4">
-                {yearData.schools.entriesArr().map(([school, schoolData]) => {
-                  const dataByPhase = schoolData.stable
-                    .map((sr) => {
-                      const mr = schoolData.main.find(
-                        (rr) => rr.phase === sr.phase,
-                      );
-                      if (!mr) return [];
-
-                      return [
-                        sr.phase,
-                        sr.rankingSummary.howManyStudents.toString(),
-                        mr.rankingSummary.howManyStudents.toString(),
-                      ];
-                    })
-                    .filter((arr) => arr.length === 3);
-
-                  console.log(yearsMaxRows.get(year));
-                  const voidRowsNum =
-                    (yearsMaxRows.get(year) ?? 0) - dataByPhase.length;
-                  const voidRows: number[] = new Array(
-                    Math.max(voidRowsNum, 0),
-                  ).fill(0);
-                  return (
-                    <div className="h-full basis-[calc(50%-1rem)] rounded-md border border-slate-300 dark:border-slate-700 [&_*]:border-slate-300 [&_*]:dark:border-slate-700">
-                      <Table className="h-full [&_tr:nth-child(odd):not(:hover)]:bg-inherit dark:[&_tr:nth-child(odd):not(:hover)]:bg-inherit">
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead>{school}</TableHead>
-                            <TableHead>{stable.ref}</TableHead>
-                            <TableHead>{main.ref}</TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {dataByPhase.map((d) => {
-                            return (
-                              <TableRow key={d[0]}>
-                                <TableCell className="w-3/5">{d[0]}</TableCell>
-                                <TableCell className="w-1/5">{d[1]}</TableCell>
-                                <TableCell className="w-1/5">{d[2]}</TableCell>
-                              </TableRow>
-                            );
-                          })}
-                          {voidRows.map((_, i) => (
-                            <TableRow key={`void-${year}-${school}-${i}`}>
-                              <TableCell colSpan={3}>&nbsp;</TableCell>
-                            </TableRow>
-                          ))}
-                          <TableRow className="[&_*]:bg-slate-800">
-                            <TableCell>Comparison (stable - main)</TableCell>
-                            <TableCell>
-                              {schoolData.comparison.diffStableMain}
-                            </TableCell>
-                            <TableCell>
-                              {schoolData.comparison.diffStableMainPercentage.toFixed(
-                                2,
-                              )}
-                              %
-                            </TableCell>
-                          </TableRow>
-                        </TableBody>
-                      </Table>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
-          {canLoadMore && (
-            <Button variant="outline" onClick={load}>
-              Load more
-            </Button>
-          )}
-        </>
-      )}
-      {isLoading && <Spinner className="flex-grow-0" />}
-    </div>
   );
 }

--- a/src/components/custom-ui/Spinner.tsx
+++ b/src/components/custom-ui/Spinner.tsx
@@ -1,14 +1,23 @@
-import { useContext } from "react";
+import { HTMLAttributes, useContext } from "react";
 import { PuffLoader } from "react-spinners";
 import DarkModeContext from "@/contexts/DarkModeContext";
+import { cn } from "@/utils/ui";
 
-interface Props {
+type Props = HTMLAttributes<HTMLDivElement> & {
   loading?: boolean;
-}
-export default function Spinner({ loading = true }: Props) {
+};
+
+export default function Spinner({
+  loading = true,
+  className,
+  ...props
+}: Props) {
   const { isDarkMode } = useContext(DarkModeContext);
   return (
-    <div className="flex flex-1 items-center justify-center">
+    <div
+      className={cn("flex flex-1 items-center justify-center", className)}
+      {...props}
+    >
       <PuffLoader
         color={isDarkMode ? "#ffffff" : "#333333"}
         loading={loading}

--- a/src/utils/data/data.ts
+++ b/src/utils/data/data.ts
@@ -266,4 +266,23 @@ export default class Data {
 
     return phases;
   }
+
+  public async getAllYearRankings(
+    school: School,
+    year: number,
+  ): Promise<Ranking[]> {
+    const r: Ranking[] = [];
+    const phases = await this.getPhases(school, year);
+
+    if (!phases) return r;
+
+    const hrefs = phases.all.map((pl) => pl.href);
+
+    for (const href of hrefs) {
+      const ranking = await this.loadRanking(school, year, href);
+      if (ranking) r.push(ranking);
+    }
+
+    return r;
+  }
 }


### PR DESCRIPTION
Siccome è difficile valutare se il branch `main` di RankingsDati (generato dal branch `main` di GraduatorieScriptCSharp) contiene o no errori (quindi per valutare la fattibilità di una release), viene introdotta una nuova sezione all'interno dei tools dev per comparare il numero di studenti di tutte le ranking di tutte le scuole relative a un anno, tra main e stable.

Di base vengono visualizzati gli ultimi due anni (es. 2023, 2022) ma è possibile estendere la view anche agli anni precedenti con il tasto in basso.

Proprio per la natura dello strumento, visualizzare questi dati può richiedere del tempo (specialmente se si è su connessioni lente).