### PR TITLE
perf: replace useEffect(s) with dedicated functions

### DIFF
--- a/src/components/DevSettings/index.tsx
+++ b/src/components/DevSettings/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "../ui/button";
 import Data from "@/utils/data/data";
 import { LuSettings2, LuX } from "react-icons/lu";
@@ -15,17 +15,14 @@ type LocalData = {
 
 export default function DevSettings({ data }: { data?: Data }) {
   const [open, setOpen] = useState(false);
-
   const [{ stable, main }, setLocalData] = useState<LocalData>({});
 
-  useEffect(() => {
-    const mainData = Data.init(DATA_REF.MAIN);
-    const stableData = Data.init(DATA_REF.STABLE);
+  const mainData = Data.init(DATA_REF.MAIN);
+  const stableData = Data.init(DATA_REF.STABLE);
 
-    Promise.all([mainData, stableData]).then(([main, stable]) =>
-      setLocalData({ main, stable }),
-    );
-  }, []);
+  Promise.all([mainData, stableData]).then(([main, stable]) =>
+    setLocalData({ main, stable }),
+  );
 
   return (
     data && (

--- a/src/contexts/DarkModeContext.tsx
+++ b/src/contexts/DarkModeContext.tsx
@@ -1,5 +1,5 @@
 import { LOCAL_STORAGE } from "@/utils/constants";
-import { createContext, useEffect, useState } from "react";
+import { createContext, useState } from "react";
 
 export interface IDarkModeContext {
   isDarkMode: boolean;
@@ -29,28 +29,30 @@ function getInitialValue(): boolean {
   return ls === null ? getCssValue() : ls;
 }
 
+function updateDOMWithTheme(isDarkMode: boolean): void {
+  if (isDarkMode) {
+    document.documentElement.classList.add("dark");
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute("content", "#00172A");
+  } else {
+    document.documentElement.classList.remove("dark");
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute("content", "#FFFFFF");
+  }
+}
+
 type Props = React.HTMLAttributes<React.ProviderProps<IDarkModeContext>>;
 export function DarkModeProvider({ ...p }: Props) {
   const [isDarkMode, setIsDarkMode] = useState(getInitialValue());
-
-  useEffect(() => {
-    if (isDarkMode) {
-      document.documentElement.classList.add("dark");
-      document
-        .querySelector('meta[name="theme-color"]')
-        ?.setAttribute("content", "#00172A");
-    } else {
-      document.documentElement.classList.remove("dark");
-      document
-        .querySelector('meta[name="theme-color"]')
-        ?.setAttribute("content", "#FFFFFF");
-    }
-  }, [isDarkMode]);
+  updateDOMWithTheme(isDarkMode);
 
   const toggleDarkMode = () => {
     setIsDarkMode((value) => {
       const newValue = !value;
       localStorage.setItem(LOCAL_STORAGE.darkMode, JSON.stringify(newValue));
+      updateDOMWithTheme(newValue);
       return newValue;
     });
   };

--- a/src/routes/viewer/index.tsx
+++ b/src/routes/viewer/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { ErrorComponent, Navigate, Route, useNavigate } from "@tanstack/router";
 import MobileContext from "@/contexts/MobileContext";
 import School from "@/utils/types/data/School.ts";
@@ -9,7 +9,7 @@ import {
   Phases,
 } from "@/utils/types/data/parsed/Index/RankingFile.ts";
 import { ABS_ORDER } from "@/utils/constants.ts";
-import Store from "@/utils/data/store.ts";
+import Store, { CourseInfoLocation } from "@/utils/data/store.ts";
 import Spinner from "@/components/custom-ui/Spinner.tsx";
 import Page from "@/components/custom-ui/Page.tsx";
 import PathBreadcrumb from "@/components/PathBreadcrumb.tsx";
@@ -19,6 +19,39 @@ import PhaseSelect from "./PhaseSelect";
 import { CourseCombobox } from "./CourseCombobox.tsx";
 import LocationsSelect from "./LocationSelect.tsx";
 import { NotFoundError } from "@/utils/errors.ts";
+
+function isSelectedLocationValid(
+  locations: CourseInfoLocation[],
+  selectedLocation: string,
+): boolean {
+  if (locations.length === 0) return false;
+  const foundLocation = locations.find(
+    (cil) => cil.value.toLowerCase() === selectedLocation?.toLowerCase(),
+  );
+
+  return !!foundLocation;
+}
+
+function getLocationsByNumStudents(
+  locations: CourseInfoLocation[],
+): CourseInfoLocation[] {
+  const sortedByNumStudents = Array.from(locations);
+  sortedByNumStudents.sort((a, b) => b.numStudents - a.numStudents);
+  return sortedByNumStudents;
+}
+
+function fallbackSelectedLocation(
+  locations: CourseInfoLocation[],
+  selectedLocation?: string,
+): CourseInfoLocation | undefined {
+  if (selectedLocation) {
+    const valid = isSelectedLocationValid(locations, selectedLocation);
+    if (valid) return undefined;
+  }
+
+  const sortedLocations = getLocationsByNumStudents(locations);
+  return sortedLocations[0];
+}
 
 export const viewerRoute = new Route({
   getParentRoute: () => rootRoute,
@@ -42,82 +75,90 @@ export const viewerRoute = new Route({
     return <ErrorComponent error={error} />;
   },
   component: function Viewer({ useLoader, useParams }) {
-    const { phases: _phases, ranking, data } = useLoader();
-    const { school, year, phase } = useParams();
+    const {
+      phases: _phases,
+      ranking,
+      data,
+      phaseLink: initialPhaseLink,
+      phaseGroup: initialPhaseGroup,
+    } = useLoader();
+    const { school, year } = useParams();
     const { isMobile } = useContext(MobileContext);
     const navigate = useNavigate({ from: viewerRoute.id });
-
     const store = useMemo(() => ranking && new Store(ranking), [ranking]);
 
     const courses = store?.getCourses();
     const [selectedCourse, setSelectedCourse] = useState<string>(ABS_ORDER);
-
-    const locations = useMemo(
-      () => courses?.get(selectedCourse)?.locations ?? [],
-      [courses, selectedCourse],
+    const isAbsOrder = useMemo(
+      () => selectedCourse === ABS_ORDER,
+      [selectedCourse],
     );
+
+    const [locations, setLocations] = useState<CourseInfoLocation[]>([]);
     const [selectedLocation, setSelectedLocation] = useState<
       string | undefined
     >();
-    useEffect(() => {
-      if (locations.length === 0) return;
-      const findLocation = locations.find(
-        (cil) => cil.value.toLowerCase() === selectedLocation?.toLowerCase(),
-      );
-      if (!findLocation) {
-        const sortedByNumStudents = Array.from(locations);
-        sortedByNumStudents.sort((a, b) => b.numStudents - a.numStudents);
-        const { value } = sortedByNumStudents[0];
-        setSelectedLocation(value);
-      }
-    }, [locations, selectedLocation]);
 
     const [phases, setPhases] = useState<Phases>(_phases);
     const [selectedPhaseLink, setSelectedPhaseLink] = useState<
       PhaseLink | undefined
-    >();
+    >(initialPhaseLink);
     const [selectedPhaseGroup, setSelectedPhaseGroup] = useState<
       PhaseGroup | undefined
-    >();
+    >(initialPhaseGroup);
 
-    useEffect(() => {
-      if (selectedPhaseLink) return;
-
-      const link = phases.all.find((p) => p.href === phase);
-      if (!link) return;
-
-      setSelectedPhaseLink(link);
-
-      const group = phases.groups.get(link.group.value);
-      if (!group) return;
-
-      setSelectedPhaseGroup(group);
-    }, [phase, phases, selectedPhaseLink]);
-
-    const handlePhaseChange = (link: PhaseLink, group: PhaseGroup) => {
+    function handlePhaseChange(link: PhaseLink, group: PhaseGroup): void {
       setSelectedPhaseLink(link);
       setSelectedPhaseGroup(group);
       navigate({
         to: "/view/$school/$year/$phase",
         params: { school, year, phase: link.href },
       });
-    };
+    }
+
+    async function updateAvailablePhases(): Promise<void> {
+      // check if this needs a useCallback to update
+      // isAbsOrder value between re-renders
+      if (isAbsOrder) return setPhases(_phases);
+
+      // check if this needs a useCallback to update
+      // school year and table
+      const coursePhases = await data.getPhases(
+        school,
+        year,
+        table as CourseTable,
+      );
+      const phases = coursePhases ?? _phases;
+      setPhases(phases);
+    }
+
+    function handleCourseChange(value: string): void {
+      setSelectedCourse(value);
+      const courseLocations = courses?.get(value)?.locations;
+      if (courseLocations) {
+        setLocations(courseLocations);
+        const fallback = fallbackSelectedLocation(
+          courseLocations,
+          selectedLocation,
+        );
+        if (fallback) setSelectedLocation(fallback.value);
+
+        updateAvailablePhases();
+      }
+    }
+
+    function handleLocationChange(value: string): void {
+      setSelectedLocation(value);
+      const fallback = fallbackSelectedLocation(locations, value);
+      if (fallback) setSelectedLocation(fallback.value);
+
+      updateAvailablePhases();
+    }
 
     const table = useMemo(
       () => store.getTable(selectedCourse, selectedLocation),
       [selectedCourse, selectedLocation, store],
     );
-
-    useEffect(() => {
-      if (!table) return;
-      if (selectedCourse === ABS_ORDER) {
-        setPhases(_phases);
-      } else {
-        data
-          .getPhases(school, year, table as CourseTable)
-          .then((links) => setPhases(links ?? _phases));
-      }
-    }, [data, _phases, ranking, school, selectedCourse, table, year]);
 
     return (
       <Page
@@ -145,13 +186,13 @@ export const viewerRoute = new Route({
               <CourseCombobox
                 courses={courses}
                 value={selectedCourse}
-                onSelect={setSelectedCourse}
+                onSelect={handleCourseChange}
               />
               {selectedLocation && (
                 <LocationsSelect
                   value={selectedLocation}
                   locations={locations}
-                  onChange={setSelectedLocation}
+                  onChange={handleLocationChange}
                 />
               )}
             </div>

--- a/src/utils/loaders/rankingLoader.ts
+++ b/src/utils/loaders/rankingLoader.ts
@@ -16,7 +16,10 @@ export const rankingLoader = new Loader({
     const phases = await data.getPhases(school, year);
     const ranking = await data.loadRanking(school, year, phase);
 
+    const phaseLink = phases?.all.find((p) => p.href === phase);
+    const phaseGroup = phaseLink && phases?.groups.get(phaseLink.group.value);
+
     if (!ranking || !phases) throw new NotFoundError();
-    return { ranking, phases, data };
+    return { ranking, phases, data, phaseLink, phaseGroup };
   },
 });


### PR DESCRIPTION
Following guidelines, I removed all improperly used useEffects (actually all useEffects) in favor of dedicated micro-functions that works independently from state and event handlers which use micro-functions and update state.

Note: Not every event handling code part uses this approch yet.

## POSSIBLE BREAKING CHANGE
Changed the way Viewer component works (the one which handles the tables view and phase/course/location selection), further investigations should be done to check the UX and the expected behaviors are preserved (@angeousta)

Note: merging does not affect release directly, but a future release will include this change, so it's better to investigate before merging. 