### PR TITLE
fix: hashed-id column shown even if no data (ING-2020 affected)

### DIFF
--- a/src/routes/viewer/Table/Toolbar.tsx
+++ b/src/routes/viewer/Table/Toolbar.tsx
@@ -19,18 +19,13 @@ export function Toolbar({ has, onCsvClick, table }: Props) {
 
   return (
     <div className="flex w-full flex-wrap items-center justify-start gap-4 max-sm:items-start max-2xs:flex-col">
-      {table.getColumn("matricola-hash") && (
+      {table.getColumn("id") && (
         <Input
           className="w-full sm:max-w-[300px]"
           placeholder="Filter per matricola..."
-          value={
-            (table.getColumn("matricola-hash")?.getFilterValue() as string) ??
-            ""
-          }
+          value={(table.getColumn("id")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
-            table
-              .getColumn("matricola-hash")
-              ?.setFilterValue(event.target.value)
+            table.getColumn("id")?.setFilterValue(event.target.value)
           }
         />
       )}

--- a/src/routes/viewer/Table/columns.tsx
+++ b/src/routes/viewer/Table/columns.tsx
@@ -3,7 +3,7 @@ import { capitaliseWords } from "@/utils/strings/capitalisation";
 import StudentResult from "@/utils/types/data/parsed/Ranking/StudentResult";
 import { FilterOption } from "./FilterBtn";
 
-  export const enrollAllowedOpts: FilterOption<boolean>[] = [
+export const enrollAllowedOpts: FilterOption<boolean>[] = [
   {
     originalValue: true,
     value: "si",
@@ -204,7 +204,7 @@ export function getColumns(rows: StudentResult[]): ColumnDef<StudentResult>[] {
         {
           accessorKey: "id",
           header: "Matricola hash",
-          id: "matricola-hash",
+          id: "id",
           cell: ({ getValue }) => {
             const value = getValue();
             return Formatter.displayHash(value);

--- a/src/routes/viewer/Table/index.tsx
+++ b/src/routes/viewer/Table/index.tsx
@@ -76,9 +76,9 @@ type ColumnVisibility = {
 export default function Table({ table: _table, csvFilename }: TableProps) {
   const { rows } = _table;
   const has = makeHas(rows);
-  const columns = getColumns(rows);
   const [columnVisibility, setColumnVisibility] =
     useState<ColumnVisibility>(has);
+  const columns = getColumns(rows);
   const [pagination, setPagination] = useState<PaginationState>({
     pageSize: 15,
     pageIndex: 0,


### PR DESCRIPTION
there was the `matricola hash` column id named differently across the codebased, causing a visibility issue which was showing the column even if no data was available.
Now the col id has been changed from `matricola-hash` to `id` to reflect both the json and the JS object field name.
Note: renaming every name related to this field to `matricolaHash` would be a proper change

closes #211