### PR TITLE
feat: add flags to display ranking language

### DIFF
--- a/src/components/custom-ui/PhaseFlag.tsx
+++ b/src/components/custom-ui/PhaseFlag.tsx
@@ -1,0 +1,9 @@
+import { PhaseLink } from "@/utils/types/data/parsed/Index/RankingFile";
+
+export default function PhaseFlag({ phase }: { phase: PhaseLink }) {
+  return phase.order.isEnglish ? (
+    <span>&#x1F1EC;&#x1F1E7;</span>
+  ) : (
+    <span>&#x1F1EE;&#x1F1F9;</span>
+  );
+}

--- a/src/routes/homepage/choosePhase.tsx
+++ b/src/routes/homepage/choosePhase.tsx
@@ -9,6 +9,7 @@ import {
   PhaseLink,
 } from "@/utils/types/data/parsed/Index/RankingFile";
 import { NO_GROUP } from "@/utils/constants";
+import PhaseFlag from "@/components/custom-ui/PhaseFlag";
 
 export const choosePhaseRoute = new Route({
   getParentRoute: () => homepageRoute,
@@ -94,8 +95,17 @@ function Buttons({ school, year, phases }: ButtonsProps) {
           key={phase.href}
           className="h-full"
         >
-          <Button size="card" variant="secondary" className="h-full w-full">
-            <span className="text-base">{phase.name}</span>
+          <Button
+            size="card"
+            variant="secondary"
+            className="relative h-full w-full"
+          >
+            <span className="whitespace text-base">{phase.name}</span>
+            <div className="absolute bottom-0 right-0 flex overflow-hidden rounded-tl-lg">
+              <div className="bg-slate-700 px-3 py-1">
+                <PhaseFlag phase={phase} />
+              </div>
+            </div>
           </Button>
         </Link>
       ))}

--- a/src/routes/viewer/PhaseSelect/RankingSelect/Combobox.tsx
+++ b/src/routes/viewer/PhaseSelect/RankingSelect/Combobox.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { State } from "@/utils/types/state";
 import { PhaseLink } from "@/utils/types/data/parsed/Index/RankingFile";
+import PhaseFlag from "@/components/custom-ui/PhaseFlag";
 
 export type RankingComboboxProps = {
   rankingOpen: State<boolean>;
@@ -41,7 +42,7 @@ export default function RankingCombobox({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="outline" className="h-full justify-start">
-          {selectedPhase.name}
+          <span className="mr-1">{selectedPhase.name}</span> <PhaseFlag phase={selectedPhase} />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="p-0" side="bottom" align="start">
@@ -57,7 +58,8 @@ export default function RankingCombobox({
                     onSelect={handleChange}
                     value={phase.href}
                   >
-                    {phase.name}
+                    <span className="mr-1">{phase.name}</span>
+                    <PhaseFlag phase={phase} />
                   </CommandItem>
                 ))}
               </ScrollArea>

--- a/src/routes/viewer/PhaseSelect/RankingSelect/Tabs.tsx
+++ b/src/routes/viewer/PhaseSelect/RankingSelect/Tabs.tsx
@@ -1,3 +1,4 @@
+import PhaseFlag from "@/components/custom-ui/PhaseFlag";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PhaseLink } from "@/utils/types/data/parsed/Index/RankingFile";
 
@@ -34,7 +35,7 @@ export default function RankingTabs({
             value={phase.href}
             key={phase.href}
           >
-            {phase.name}
+            {phase.name} <PhaseFlag phase={phase} />
           </TabsTrigger>
         ))}
       </TabsList>

--- a/src/utils/data/data.ts
+++ b/src/utils/data/data.ts
@@ -130,8 +130,8 @@ export default class Data {
     const order = file.rankingOrder;
     const name = order.secondary
       ? `${numberToRoman(order.secondary || 1)} graduatoria ${
-          order.isEnglish ? "(ENG)" : ""
-        } ${order.isExtraEu ? "(Extra-UE)" : ""}`
+          order.isExtraEu ? "(Extra-UE)" : ""
+        }`
       : order.phase;
 
     const phaseNum = order.primary


### PR DESCRIPTION
Proposal to display ranking language with the corresponding flag (ita or eng).
At the moment, when the ranking is english `(ENG)` is displayed, but this causes the text to wrap in buttons and to be too large in the tab selector.
With the flags we recover some space and it's visually more catchable.

As the `preview` is not working (see #225), here are the screenshots:

<table>
  <tr>
    <td>
      <img src="https://github.com/PoliNetworkOrg/Rankings/assets/66379281/c0380a85-f5b7-405f-aff3-eae56eaa9829" alt="image" />
    </td>
    <td rowspan="2">
      <img src="https://github.com/PoliNetworkOrg/Rankings/assets/66379281/4a89d879-8637-4765-944c-b40514ca3e28" alt="localhost_5173_(iPhone SE)" />
    </td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/PoliNetworkOrg/Rankings/assets/66379281/6f88f9af-0c21-47c7-97fb-fd372dd0eafa" alt="image" />
    </td>
  </tr>
</table>
