### PR TITLE
feat(FilterBtn): render static/preselected option if only one available

### DIFF
--- a/src/routes/viewer/Table/FilterBtn.tsx
+++ b/src/routes/viewer/Table/FilterBtn.tsx
@@ -19,6 +19,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
+import { Removable } from "@/components/custom-ui/Removable";
 
 export type FilterOption<T> = {
   originalValue: T;
@@ -41,7 +42,7 @@ export function FilterBtn<TData, TValue>({
   const facets = column.getFacetedUniqueValues();
   const selectedValues = new Set(column?.getFilterValue() as string[]);
 
-  return (
+  return facets.size >= 2 ? (
     <Popover>
       <PopoverTrigger asChild>
         <Button
@@ -156,5 +157,16 @@ export function FilterBtn<TData, TValue>({
         </Command>
       </PopoverContent>
     </Popover>
+  ) : (
+    <Removable showRemove={false}>
+      {title}
+      <Separator
+        orientation="vertical"
+        className="mx-2 h-4 bg-slate-400 dark:bg-slate-600"
+      />
+      {facets.size === 1 && Array.from(facets.keys())[0]
+        ? options[0].label
+        : "N/A"}
+    </Removable>
   );
 }


### PR DESCRIPTION
if there is only one option available, instead of showing the filter, show a "badge" with the only choice available.
This could happen in a multi-filter situation. 
e.g. selecting "Prenotato" in the "Stato" filter would make "Si" the only option available in "Immatricolabile" filter, so we show directly the "Immatricolabile: Si" selected.

![image](https://github.com/user-attachments/assets/9c64ea52-066d-4e8b-8e50-d7e85092d653)

Notice the difference between the "Stato" filter (dotted with transparent bg => can click and change) and the "Immatricolabile" one (with light bg and no dotted border,  title and selected option on the same hierarchy level)

This is a similar behaviour like the course-location multi-select filters: if a course has only one location, we select it and make it "unchangeable" with a similar UI/UX.

![image](https://github.com/user-attachments/assets/84c320cf-f0e2-4c35-bd2b-5638dc7e01f1)
